### PR TITLE
Replaced ref parameters in GetField with out

### DIFF
--- a/JSONObject.cs
+++ b/JSONObject.cs
@@ -456,10 +456,9 @@ public class JSONObject {
 	}
 	public delegate void FieldNotFound(string name);
 	public delegate void GetFieldResponse(JSONObject obj);
-	public bool GetField(ref bool field, string name, bool fallback) {
-		if (GetField(ref field, name)) { return true; }
+	public bool GetField(out bool field, string name, bool fallback) {
 		field = fallback;
-		return false;
+		return GetField(ref field, name);
 	}
 	public bool GetField(ref bool field, string name, FieldNotFound fail = null) {
 		if(type == Type.OBJECT) {
@@ -473,13 +472,12 @@ public class JSONObject {
 		return false;
 	}
 #if USEFLOAT
-	public bool GetField(ref float field, string name, float fallback) {
+	public bool GetField(out float field, string name, float fallback) {
 #else
-	public bool GetField(ref double field, string name, double fallback) {
+	public bool GetField(out double field, string name, double fallback) {
 #endif
-		if (GetField(ref field, name)) { return true; }
 		field = fallback;
-		return false;
+		return GetField(ref field, name);
 	}
 #if USEFLOAT
 	public bool GetField(ref float field, string name, FieldNotFound fail = null) {
@@ -496,10 +494,9 @@ public class JSONObject {
 		if(fail != null) fail.Invoke(name);
 		return false;
 	}
-	public bool GetField(ref int field, string name, int fallback) {
-		if (GetField(ref field, name)) { return true; }
+	public bool GetField(out int field, string name, int fallback) {
 		field = fallback;
-		return false;
+		return GetField(ref field, name);
 	}
 	public bool GetField(ref int field, string name, FieldNotFound fail = null) {
 		if (IsObject) {
@@ -512,10 +509,9 @@ public class JSONObject {
 		if(fail != null) fail.Invoke(name);
 		return false;
 	}
-	public bool GetField(ref uint field, string name, uint fallback) {
-		if (GetField(ref field, name)) { return true; }
+	public bool GetField(out uint field, string name, uint fallback) {
 		field = fallback;
-		return false;
+		return GetField(ref field, name);
 	}
 	public bool GetField(ref uint field, string name, FieldNotFound fail = null) {
 		if (IsObject) {
@@ -528,10 +524,9 @@ public class JSONObject {
 		if(fail != null) fail.Invoke(name);
 		return false;
 	}
-	public bool GetField(ref string field, string name, string fallback) {
-		if (GetField(ref field, name)) { return true; }
+	public bool GetField(out string field, string name, string fallback) {
 		field = fallback;
-		return false;
+		return GetField(ref field, name);
 	}
 	public bool GetField(ref string field, string name, FieldNotFound fail = null) {
 		if (IsObject) {


### PR DESCRIPTION
Changed the 'ref' parameters to 'out' in the GetField overloads with a fallback value.
This aligns better with the purpose of the function. (Since GetField guarantees that "field" will be assigned upon exiting the function.)
A small advantage is that GetField can now be called without first having to assign a value to the field variable, which, in my opinion, also makes it slightly neater.
ex.  int id = -1; GetField(ref id, "id", -1);
vs.  int id; GetField(out id, "id", -1);

Finally, since the overloads with the FieldNotFound delegate still have a 'ref' parameter, people with already initialized variables can continue to use those functions.