### PR TITLE
Add IEnumerable to JSONObject so it can be used in foreach

### DIFF
--- a/JSONObject.cs
+++ b/JSONObject.cs
@@ -33,7 +33,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-public class JSONObject {
+public class JSONObject : IEnumerable {
 #if POOLING
 	const int MAX_POOL_SIZE = 10000;
 	public static Queue<JSONObject> releaseQueue = new Queue<JSONObject>();
@@ -1120,4 +1120,64 @@ public class JSONObject {
 		}
 	}
 #endif
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return (IEnumerator)GetEnumerator();
+    }
+
+    public JSONObjectEnumer GetEnumerator()
+    {
+        return new JSONObjectEnumer(this);
+    }
+}
+
+public class JSONObjectEnumer : IEnumerator
+{
+    public JSONObject _jobj;
+
+    // Enumerators are positioned before the first element
+    // until the first MoveNext() call.
+    int position = -1;
+
+    public JSONObjectEnumer(JSONObject jsonObject)
+    {
+        Debug.Assert(jsonObject.isContainer); //must be an array or object to itterate
+        _jobj = jsonObject;
+    }
+
+    public bool MoveNext()
+    {
+        position++;
+        return (position < _jobj.Count);
+    }
+
+    public void Reset()
+    {
+        position = -1;
+    }
+
+    object IEnumerator.Current
+    {
+        get
+        {
+            return Current;
+        }
+    }
+
+    public JSONObject Current
+    {
+        get
+        {
+            if (_jobj.IsArray)
+            {
+                return _jobj[position];
+            }
+            else
+            {
+                string key = _jobj.keys[position];
+                return _jobj[key];
+            }
+        }
+    }
 }


### PR DESCRIPTION
* doesnt allocate new objects (other than the enumerator) so it doesnt
create a bunch of garbage
* unit tested in my Unity project

[Test]
public void JsonObjectEnumerable()
{
string strJson1 = "{ \"blah\":5 }";
string strJson2 = @"{
""name"": ""Attack"",
""castTime"": 1.15,
""cooldownTime"": 1.85,
""range"": 500,
""effectsOnCast"": [
{
""effectType"": ""damage"",
""damageType"": ""piercing"",
""targetStat"": ""hp_curr"",
""valueBase"": 2,
""valueStat"": ""str"",
""valueMultiplier"": 2,
""react"": ""shake""
},
{
""effectType"": ""healing"",
""targetStat"": ""hp_curr"",
""valueBase"": 2,
""valueStat"": ""int"",
""valueMultiplier"": 2
}
]
}";

JSONObject j = new JSONObject(strJson1);
Debug.Log("j: - " + j);
Debug.Log("j['blah']: 5 -  " + j["blah"]);
j = new JSONObject(strJson2);
if (j["effectsOnCast"])
{
Debug.Log("j: effectsOnCast length: " + j["effectsOnCast"].Count);

float valueBase = j["effectsOnCast"][0]["valueBase"].f;
Debug.Log("j: effectsOnCast[0].valueBase " + valueBase);

foreach (JSONObject eff in j["effectsOnCast"])
{
string react;
eff.GetField(out react, "react", "no reaction");
Debug.Log("j: react type - " + react);

if (!eff["damageType"]) continue;
string damageType = eff["damageType"].str;
Debug.Log("j: damage type " + damageType);
}
}
else
{
Debug.Log("j: effectsOnCast DNE ");
}
}