### PR TITLE
Avoid precision errors when retrieving longs, ints

### DIFF
--- a/JSONObject.cs
+++ b/JSONObject.cs
@@ -563,7 +563,7 @@ public class JSONObject : IEnumerable {
 		if(IsObject) {
 			int index = keys.IndexOf(name);
 			if(index >= 0) {
-				field = (int)list[index].n;
+				field = (int)list[index].i;
 				return true;
 			}
 		}
@@ -578,7 +578,7 @@ public class JSONObject : IEnumerable {
 		if(IsObject) {
 			int index = keys.IndexOf(name);
 			if(index >= 0) {
-				field = (long)list[index].n;
+				field = (long)list[index].i;
 				return true;
 			}
 		}
@@ -593,7 +593,7 @@ public class JSONObject : IEnumerable {
 		if(IsObject) {
 			int index = keys.IndexOf(name);
 			if(index >= 0) {
-				field = (uint)list[index].n;
+				field = (uint)list[index].i;
 				return true;
 			}
 		}


### PR DESCRIPTION
Use the .i field directly when retriving longs, ints and uints instead
of using the float field. This avoids truncation errors for large
integers.