### PR TITLE
Fix Add method for long parameter

### DIFF
--- a/JSONObject.cs
+++ b/JSONObject.cs
@@ -444,6 +444,9 @@ public class JSONObject : IEnumerable {
 	public void Add(float val) {
 		Add(Create(val));
 	}
+	public void Add(long val) {
+		Add(Create(val));
+	}
 	public void Add(int val) {
 		Add(Create(val));
 	}


### PR DESCRIPTION
The following code did not produce the expected result:
```
JSONObject json = new JSONObject();
json.AddField("times", new JSONObject(JSONObject.Type.ARRAY));
long input = 1234;
json.GetField("times").Add(input);
long output = json.GetField("times")[0].i;
```